### PR TITLE
Get rid of dynamic properties to support PHP8.2

### DIFF
--- a/src/Util/IdFactory.php
+++ b/src/Util/IdFactory.php
@@ -95,6 +95,7 @@ class IdFactory {
     protected int $initialSequenceNumber;
     protected int $hrOffset;
     protected ?int $_machineId = null;
+    private array $options;
 
     /**
      * Used by `self::getSequenceNumber()` to trigger generating a new initial sequence number

--- a/src/Util/IdFactory.php
+++ b/src/Util/IdFactory.php
@@ -277,7 +277,7 @@ class IdFactory {
      * Generate a snowflake ID.
      */
     public function snowflake(): int {
-        return ((((microtime(true) - $this->epoch) * 1000) & 0x1FFFFFFFFFF) << 22)
+        return ((intval((microtime(true) - $this->epoch) * 1000) & 0x1FFFFFFFFFF) << 22)
             | ((($this->_machineId ?? $this->getMachineId()) & 0x3FF) << 12)
             | ($this->getSequenceNumber() & 0xFFF);
     }


### PR DESCRIPTION
Property options has not been declared as class propery, simple declaration seem to suffice